### PR TITLE
A quick fix for supporting macosx

### DIFF
--- a/gitv
+++ b/gitv
@@ -1,4 +1,4 @@
-#!/usr/bin/lua
+#!/usr/bin/env lua
 local isWin=string.find(string.lower(os.getenv('OS') or 'nil'),'windows')~=nil
 if isWin then
 	package.path =os.getenv('HOMEDRIVE')..os.getenv('HOMEPATH').."/bin/?.lua" .. ";"..package.path 

--- a/gitvall
+++ b/gitvall
@@ -1,4 +1,4 @@
-#!/usr/bin/lua
+#!/usr/bin/env lua
 local gitvPath
 local isWin=string.find(string.lower(os.getenv('OS') or 'nil'),'windows')~=nil
 if isWin then

--- a/mylib.lua
+++ b/mylib.lua
@@ -2387,7 +2387,7 @@ end
 
 -- escape so that it can be used in double quotes
 function os.shellEscape(str)
-	if os.isUnix() then
+	if os.isUnix() or os.isApple() then
 		str=string.gsub(str, '\\', '\\\\')
 		str=string.gsub(str, '"', '\\"')
 		str=string.gsub(str, '%%', '\\%%')

--- a/mylib52.lua
+++ b/mylib52.lua
@@ -2382,7 +2382,7 @@ end
 
 -- escape so that it can be used in double quotes
 function os.shellEscape(str)
-	if os.isUnix() then
+	if os.isUnix() or os.isApple() then
 		str=string.gsub(str, '\\', '\\\\')
 		str=string.gsub(str, '"', '\\"')
 		str=string.gsub(str, '%%', '\\%%')


### PR DESCRIPTION
To make this work, I modified shebang to use path independent lua program at first. And then fixing shell escaping error by treating apple shell as a unix shell.

I've tested this code from environment below.
 * Mac OS 10.12.1 (Sierra)
 * Lua: Lua 5.2.4